### PR TITLE
Allows keyboard input from CLI

### DIFF
--- a/bin/rclone.js
+++ b/bin/rclone.js
@@ -32,6 +32,12 @@ const subprocess = command ?
       command.call(rclone, ...commandArguments, flags) :
       rclone(...args, flags);
 
+try {
+  if(require.main === module) // If from CLI
+    process.stdin.pipe(subprocess.stdin); 
+} catch (error) {
+}
+
 subprocess.stdout?.on("data", (data) => {
   process.stdout.write(data);
 });

--- a/bin/rclone.js
+++ b/bin/rclone.js
@@ -33,8 +33,7 @@ const subprocess = command ?
       rclone(...args, flags);
 
 try {
-  if(require.main === module) // If from CLI
-    process.stdin.pipe(subprocess.stdin); 
+  process.stdin.pipe(subprocess.stdin); 
 } catch (error) {
 }
 


### PR DESCRIPTION
A quick fix for issue #6 
Adds a pipe from the main process to the child process.

Known errors:
Throws an error when piping `stdin` for inputs that are hidden. (Like password inputs)